### PR TITLE
Pin Sphinx-iframes

### DIFF
--- a/book/Innovating_healthcare.md
+++ b/book/Innovating_healthcare.md
@@ -291,7 +291,7 @@ According to the WHO's "Global Strategy on Digital Health 2020-2025," digital he
 
 
 ````{admonition} Watch this video by prof. Dominik Böhler about digital health
-```{video} https://www.youtube.com/embed/yGuWxu9XWoU?si=PnrLWPiVWxxGymeI
+```{video} https://www.youtube.com/watch?v=yGuWxu9XWoUlist=PLyXAaocQQ2XbCFh50vrIwm82aPfzBJBvp&index=13
 ```
 ````
 

--- a/book/Innovating_healthcare.md
+++ b/book/Innovating_healthcare.md
@@ -291,7 +291,7 @@ According to the WHO's "Global Strategy on Digital Health 2020-2025," digital he
 
 
 ````{admonition} Watch this video by prof. Dominik Böhler about digital health
-```{video} https://www.youtube.com/watch?v=yGuWxu9XWoUlist=PLyXAaocQQ2XbCFh50vrIwm82aPfzBJBvp&index=13
+```{video} https://www.youtube.com/watch?v=yGuWxu9XWoU
 ```
 ````
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ download_link_replacer
 # now list the packages (and the respective url) you wish to download from the GitLab package registry
 --extra-index-url https://gitlab.tudelft.nl/api/v4/projects/11239/packages/pypi/simple
 sphinx-thebe ~= 0.9.9
-sphinx-iframes == 1.0.4
+git+https://github.com/TeachBooks/sphinx-iframes.git@remove_list_from_youtube

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ download_link_replacer
 # now list the packages (and the respective url) you wish to download from the GitLab package registry
 --extra-index-url https://gitlab.tudelft.nl/api/v4/projects/11239/packages/pypi/simple
 sphinx-thebe ~= 0.9.9
-git+https://github.com/TeachBooks/sphinx-iframes.git@remove_list_from_youtube
+sphinx-iframes == 1.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ download_link_replacer
 # now list the packages (and the respective url) you wish to download from the GitLab package registry
 --extra-index-url https://gitlab.tudelft.nl/api/v4/projects/11239/packages/pypi/simple
 sphinx-thebe ~= 0.9.9
-sphinx-iframes
+sphinx-iframes == 1.0.4


### PR DESCRIPTION
Hi @pietervandekerckhove , I now pinned the sphinx-iframes version `sphinx-iframes == 1.0.4`. See second option here: https://teachbooks.io/manual/features/update_env.html. If you leave it like this you'll never get newer version, so you should consider option 1 or 3. You didn't get the most up-to-date version before because the older version was cached (for a week).

Furthermore your YouTube links which originate from a playlist don't work yet, I've reopend the issue: https://github.com/TeachBooks/sphinx-iframes/issues/1#issuecomment-2688568236